### PR TITLE
Enable mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  # - repo: https://github.com/executablebooks/mdformat
-  #   rev: 0.7.14
-  #   hooks:
-  #     - id: mdformat
-  #       additional_dependencies:
-  #         - mdformat-gfm
-  #         - mdformat-black
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.14
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-black
   # - repo: https://github.com/jackdewinter/pymarkdown
   #   rev: v0.9.6
   #   hooks:


### PR DESCRIPTION
@emareg I want to enable a markdown formatter that we can get some consitency into our markdown files. Right now there are for instance many random blank lines in the md files. The formatter wiuld automatically get us rid of them.

However, the formatter also changes the page header from 

```md
---
title: Title
icon: Icon
---
```

to something like

```md
# title: Title icon: Icon
```

I remember that this style was given by Jekyll. Are you using this somewhere with pandoc, then we could maybe switch to the new style to use the formatter

Maybe there are some more differences. You can test this locally by running the formatter as configured for this branch with `pre-commit run -a`